### PR TITLE
make code compatible with laravel 5.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.5
   - 5.6
   - hhvm
   - nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,6 @@ before_script:
   - travis_retry composer self-update
 
 install:
-   - composer install
+   - composer install --dev
 
 script: phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,6 @@ before_script:
   - travis_retry composer self-update
 
 install:
-   - composer install --dev
+   - composer install
 
 script: phpunit

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Laravel Version|Version
 4.x            |1.0.*
 5.0            |1.1.*
 5.1            |1.2.*
+5.2            |1.3.*
 
 ### Installation ###
 To install this package, simply put the following into your `composer.json`

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "php": ">=5.5.0",
+        "php": ">=5.5.9",
         "illuminate/support": "5.*"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "php": ">=5.5.9",
+        "php": ">=5.6",
         "illuminate/support": "5.*"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "illuminate/support": "5.*"
     },
     "require-dev": {
-      "orchestra/testbench": "3.1.*",
+      "orchestra/testbench": "3.2.*",
       "phpunit/phpunit": "~5.0"
     },
     "autoload": {

--- a/src/Codengine/CustomMigrations/Migrator.php
+++ b/src/Codengine/CustomMigrations/Migrator.php
@@ -60,10 +60,10 @@ class Migrator extends \Illuminate\Database\Migrations\Migrator {
 	 * @param array $migrations
 	 * @param bool $pretend
 	 */
-	public function runMigrationList($migrations, $pretend = FALSE)
+	public function runMigrationList($migrations, array $options=[])
 	{
 		$this->note("Running " . ($this->migrationType == "default" ? "default" : "custom") . " migrations for DB " . $this->connection);
 		$migrations = array_filter($migrations, array($this, "filterMigrations"));
-		parent::runMigrationList($migrations, $pretend);
+		parent::runMigrationList($migrations, $options);
 	}
 } 

--- a/tests/MigratorTest.php
+++ b/tests/MigratorTest.php
@@ -79,7 +79,7 @@ class MigratorTest extends PHPUnit_Framework_TestCase {
 			array('2015_03_05_012634_custom_test_migration', $custom)
 		));
 
-		$this->migrator->runMigrationList($this->migrationList);
+		$this->migrator->runMigrationList($this->migrationList, []);
 	}
 
 	public function testMigratorOnlyExecutesCustomMigration()
@@ -105,6 +105,6 @@ class MigratorTest extends PHPUnit_Framework_TestCase {
 			array('2015_03_05_012634_custom_test_migration', $custom)
 		));
 
-		$this->migrator->runMigrationList($this->migrationList);
+		$this->migrator->runMigrationList($this->migrationList, []);
 	}
 }

--- a/tests/MigratorTest.php
+++ b/tests/MigratorTest.php
@@ -79,7 +79,7 @@ class MigratorTest extends PHPUnit_Framework_TestCase {
 			array('2015_03_05_012634_custom_test_migration', $custom)
 		));
 
-		$this->migrator->runMigrationList($this->migrationList, []);
+		$this->migrator->runMigrationList($this->migrationList);
 	}
 
 	public function testMigratorOnlyExecutesCustomMigration()
@@ -105,6 +105,6 @@ class MigratorTest extends PHPUnit_Framework_TestCase {
 			array('2015_03_05_012634_custom_test_migration', $custom)
 		));
 
-		$this->migrator->runMigrationList($this->migrationList, []);
+		$this->migrator->runMigrationList($this->migrationList);
 	}
 }


### PR DESCRIPTION
The code did not work with Laravel 5.2 as  the $pretend boolean parameter has been replaced with an $options array. 

This fixes that issue, but it is not backwards compatible so probably need to move this to a new release v1.3.0. I took the liberty of creating this in my fork.

Other than that, good work on this. It was just what I needed.

I also made changes in my local code (not included in this PR) to not change settings in the vendor map to start using this package as suggested by the documentation at the moment. I would have to document it so that each developer would make that change in their local environment.

Instead I created a new ConsoleProvider class which replaces the default one in config/app.php and submitted in our git repository. 

I don't know if this is something you would like to include in your package?